### PR TITLE
Fix missing subtitles on AWS Fargate

### DIFF
--- a/c_src/subtitle_mixer/avc.c
+++ b/c_src/subtitle_mixer/avc.c
@@ -446,15 +446,20 @@ void sei_encode_eia608(sei_t* sei, cea708_t* cea708, uint16_t cc_data)
 {
     // This one is full, flush and init a new one
     // shoudl this be 32? I cant remember
-    if (31 == cea708->user_data.cc_count) {
+    uint16_t is_finished = cc_data & eia608_control_end_of_caption;
+
+    // Prevent new 708 header when caption is finished
+    if (31 == cea708->user_data.cc_count && is_finished != eia608_control_end_of_caption) {
         sei_append_708(sei, cea708);
     }
 
     if (0 == cea708->user_data.cc_count) { // This is a new 708 header, but a continuation of a 608 stream
         cea708_add_cc_data(cea708, 1, cc_type_ntsc_cc_field_1, eia608_control_command(eia608_control_resume_caption_loading, DEFAULT_CHANNEL));
+        cea708_add_cc_data(cea708, 1, cc_type_ntsc_cc_field_1, eia608_control_command(eia608_control_resume_caption_loading, DEFAULT_CHANNEL));
     }
 
     if (0 == cc_data) { // Finished
+        sei_encode_eia608(sei, cea708, eia608_control_command(eia608_control_end_of_caption, DEFAULT_CHANNEL));
         sei_encode_eia608(sei, cea708, eia608_control_command(eia608_control_end_of_caption, DEFAULT_CHANNEL));
         sei_append_708(sei, cea708);
         return;


### PR DESCRIPTION
This fix was taken from https://github.com/szatmary/libcaption/issues/44 and fixes that some subtitles were missing on the final playout.